### PR TITLE
feat: add Moon publish-release task with version confirmation

### DIFF
--- a/.moon/scripts/publish.sh
+++ b/.moon/scripts/publish.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_NAME="$1"
+
+if [ -z "$PROJECT_NAME" ]; then
+    echo "❌ Usage: $0 <project-name>"
+    exit 1
+fi
+
+# Get version from Cargo.toml
+VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$PROJECT_NAME\") | .version")
+
+if [ -z "$VERSION" ]; then
+    echo "❌ Could not find version for $PROJECT_NAME"
+    exit 1
+fi
+
+echo "🚀 Releasing $PROJECT_NAME v$VERSION"
+
+# Check git status
+if ! git diff-index --quiet HEAD --; then
+    echo "❌ Git repository has uncommitted changes. Please commit or stash them first."
+    exit 1
+fi
+
+echo "📦 Running pre-release checks..."
+
+# Run all checks
+moon run "$PROJECT_NAME:build-release"
+moon run "$PROJECT_NAME:test" 
+moon run "$PROJECT_NAME:clippy"
+moon run "$PROJECT_NAME:fmt-check"
+
+echo "🧪 Running dry run..."
+cd "crates/$PROJECT_NAME"
+cargo publish --dry-run
+
+echo "📝 Creating git tag..."
+cd ../..
+git tag "$PROJECT_NAME-v$VERSION"
+
+echo "📡 Publishing to crates.io..."
+cd "crates/$PROJECT_NAME"
+cargo publish
+
+echo "🌐 Pushing tag to origin..."
+cd ../..
+git push origin "$PROJECT_NAME-v$VERSION"
+
+echo ""
+echo "✅ Successfully released $PROJECT_NAME v$VERSION"
+echo "🔗 Tag: $PROJECT_NAME-v$VERSION"
+echo "📦 Published to: https://crates.io/crates/$PROJECT_NAME"

--- a/.moon/scripts/publish.sh
+++ b/.moon/scripts/publish.sh
@@ -3,17 +3,37 @@
 set -e
 
 PROJECT_NAME="$1"
+OVERRIDE_VERSION="$2"
 
 if [ -z "$PROJECT_NAME" ]; then
-    echo "❌ Usage: $0 <project-name>"
+    echo "❌ Usage: $0 <project-name> [version-override]"
+    echo "   Example: $0 superffi"
+    echo "   Example: $0 superffi 0.2.0"
     exit 1
 fi
 
-# Get version from Cargo.toml
-VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$PROJECT_NAME\") | .version")
+# Get version from Cargo.toml or use override
+if [ -n "$OVERRIDE_VERSION" ]; then
+    VERSION="$OVERRIDE_VERSION"
+    echo "📝 Using override version: $VERSION"
+else
+    VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$PROJECT_NAME\") | .version")
+    if [ -z "$VERSION" ]; then
+        echo "❌ Could not find version for $PROJECT_NAME"
+        exit 1
+    fi
+fi
 
-if [ -z "$VERSION" ]; then
-    echo "❌ Could not find version for $PROJECT_NAME"
+echo "📦 Package: $PROJECT_NAME"
+echo "🏷️  Version: $VERSION"
+echo ""
+
+# Confirmation prompt
+read -p "🤔 Do you want to release $PROJECT_NAME v$VERSION? (y/N): " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "❌ Release cancelled"
     exit 1
 fi
 

--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -87,3 +87,10 @@ tasks:
     command: "cargo publish"
     inputs: ["@globs(sources)", "@globs(configs)"]
     deps: ["build-release", "test", "clippy", "fmt-check"]
+
+  # Full release workflow with tagging
+  publish-release:
+    command: "../../.moon/scripts/publish.sh $project"
+    inputs: ["@globs(sources)", "@globs(configs)"]
+    options:
+      cache: false


### PR DESCRIPTION
## Summary
- Add comprehensive `publish-release` Moon task for automated crate releases
- Include interactive version confirmation with override option
- Integrate pre-release checks, dry run, tagging, and publishing
- Provide clear usage examples and error handling

## Features
- **Interactive confirmation**: Prompts user to confirm package name and version before release
- **Version override**: Support for custom version via parameter
- **Pre-release checks**: Runs build, test, clippy, and fmt-check
- **Git integration**: Creates and pushes tags automatically
- **Error handling**: Validates git status and package metadata

## Usage
```bash
# Release current version from Cargo.toml
moon run superffi:publish-release

# Release with version override
.moon/scripts/publish.sh superffi 0.2.0
```

## Test plan
- [x] Created comprehensive release script with version confirmation
- [x] Added Moon task integration
- [x] Tested script structure and error handling
- [ ] Test actual release process (will test after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)